### PR TITLE
Update read me

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@
 .vs/Softinn Code Sample/config/applicationhost.config
 .vs/Softinn Code Sample/v16/.suo
 node_modules/
-.vs/softinn-booking-engine-code-sample/FileContentIndex/cfd27a44-8388-4468-8dbd-ffacba9fa12f.vsidx
-.vs/softinn-booking-engine-code-sample/v17/.wsuo
-.vs/VSWorkspaceState.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vs/
 .vs/slnx.sqlite
 .vs/Softinn Code Sample/config/applicationhost.config
 .vs/Softinn Code Sample/v16/.suo

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .vs/Softinn Code Sample/config/applicationhost.config
 .vs/Softinn Code Sample/v16/.suo
 node_modules/
+.vs/softinn-booking-engine-code-sample/FileContentIndex/cfd27a44-8388-4468-8dbd-ffacba9fa12f.vsidx
+.vs/softinn-booking-engine-code-sample/v17/.wsuo
+.vs/VSWorkspaceState.json

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # code-sample
 Code samples for Softinn Hotel Booking Engine
 
-- [Softinn Calendar Widget](https://softinn-solutions.github.io/code-sample/calendar.html)
+- [Softinn Calendar Widget](https://github.com/Softinn-Solutions/softinn-booking-engine-code-sample/blob/master/calendar.html)


### PR DESCRIPTION
Updated the github sample code link as the previous link on the README was not working. When clicking on the previous link, it will redirect to GitHub's Error 404 page which is probably caused by the change in GitHub's link format. The new link should work where clicking it will redirect users to the calendar.html page within GitHub.